### PR TITLE
Create minimum repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/ISISComputingGroup/IBEX/wiki/PEARL-Instrument-Details
 
 ### IOC Repository: 
 
-https://github.com/ISISComputingGroup/EPICS-ioc/tree/4cd6b6a481666ea77c155126b5114b4ca3714eb3/PEARLPC
+https://github.com/ISISComputingGroup/EPICS-ioc/tree/master/PEARLPC
 
 
 ### Useful Commands:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Pearl Pressure Controller Support and Emulator 
+
+The PEARL pressure controller is an ISIS-designed device. 
+
+## Pearl Pressure Controller Useful Recourses
+
+### Technical Manual Location: 
+
+`\\isis\shares\ISIS_Experiment_Controls\Manuals\PEARL Pressure Controller\PEARL handbook_v3_5.docx`
+
+### LabVIEW VI Location: 
+
+`C:\LabVIEW Modules\Instruments\PEARL\PEARL Pressure Cell Controller`
+
+### WIKI Pages: 
+
+https://github.com/ISISComputingGroup/IBEX/wiki/PEARL-Instrument-Details
+
+### IOC Repository: 
+
+https://github.com/ISISComputingGroup/EPICS-ioc/tree/4cd6b6a481666ea77c155126b5114b4ca3714eb3/PEARLPC
+
+
+### Useful Commands:
+
+To start EPICS environment locally, simply run the `config_env` script: 
+`C:\Instrument\Apps\EPICS\config_env`
+
+When the IOC is running, you can use the following command to checks record values:
+`<epics command> %mypvprefix%PEARLPC_01:<PV record>`
+
+To test the IOC using LEWIS emulator, execute the `run_test.bat` script located:
+`master\system_tests\run_tests.bat`
+
+Add `-a` flag to `run_test.bat` to run IOC emulator and not tests straight away if wishing to view in IBEX or check PV values when testing.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ To test the IOC using LEWIS emulator, execute the `run_test.bat` script located:
 `master\system_tests\run_tests.bat`
 
 Add `-a` flag to `run_test.bat` to run IOC emulator and not tests straight away if wishing to view in IBEX or check PV values when testing.
+
+
+To test, use the [IOC Test Framework](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework) and follow [README.md](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/blob/master/README.md) documentation to run tests or emulator.
+
+Add `-a` flag when running using the IOC Test Framework to run the IOC emulator and not the tests straight away if wishing to view in IBEX or check PV values when testing.


### PR DESCRIPTION
ISSUE: [#6903](https://github.com/ISISComputingGroup/IBEX/issues/6903)

Add minimal documentation to repository README.md containing useful recourse links and commands to speed up development. 

Having some documentation inside the README is a choice agreed upon during retrospective meeting which notes can be found [HERE](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Retrospective-notes-2021.11.17)

To review:
- [ ] README.md is well structured and contains or links to all useful information that a developer may need to quickly get started working on an issue in the repository, minimising the need to leave the IDE. 