### PR TITLE
Only write to RESET:SP.DISP if value is different

### DIFF
--- a/PearlPCSup/devPearl.db
+++ b/PearlPCSup/devPearl.db
@@ -486,7 +486,11 @@ record(bi, "$(P)RESET_PRESSURE_TOO_HIGH") {
 
 record(calcout, "$(P)RESET_PRESSURE_TOO_HIGH:DISP") {
     field(INPA, "$(P)RESET_PRESSURE_TOO_HIGH")
-	field(CALC, "A")
+    field(INPB, "$(P)RESET:SP.DISP")
+	field(CALC, "A#B")
+    field(OCAL, "A")
+    field(OOPT, "When Non-zero")
+    field(DOPT, "Use OCAL")
 	field(OUT, "$(P)RESET:SP.DISP")
 }
 


### PR DESCRIPTION
This fixes the following bug:

When running up the PearlPressureController IOC via test (`run_test.bat -a`) and set a monitor on `%MYPVPREFIX%PEARLPC_01:RESET:SP.DISP` it seems to endlessly update the DISP field