### PR TITLE
Less escaping needed for new EPICS base version

### DIFF
--- a/PearlPCSup/devPearl.db
+++ b/PearlPCSup/devPearl.db
@@ -553,7 +553,7 @@ record(waveform, "$(P)ERROR_MSGS")
     field(NELM, "20")
     field(INP, ["no error", 
                 "Pressure above safe reset level",
-                "\\\\",
+                "\\",
                 ">",
                 "/",
                 "non numeric char from host PC",


### PR DESCRIPTION
Less escaping needed for new EPICS base version